### PR TITLE
feat(asv-avalonia): implement a version converter for HomePageView

### DIFF
--- a/src/Asv.Avalonia/Converters/VersionConverter.cs
+++ b/src/Asv.Avalonia/Converters/VersionConverter.cs
@@ -1,0 +1,34 @@
+using System.Globalization;
+using Avalonia.Data.Converters;
+
+namespace Asv.Avalonia
+{
+    public class VersionConverter : IValueConverter
+    {
+        public object? Convert(
+            object? value,
+            Type targetType,
+            object? parameter,
+            CultureInfo culture
+        )
+        {
+            if (value is not string version)
+            {
+                return value;
+            }
+
+            var plusIndex = version.IndexOf('+');
+            return plusIndex >= 0 ? version[..plusIndex] : version;
+        }
+
+        public object? ConvertBack(
+            object? value,
+            Type targetType,
+            object? parameter,
+            CultureInfo culture
+        )
+        {
+            throw new NotImplementedException();
+        }
+    }
+}

--- a/src/Asv.Avalonia/Shell/Pages/Home/HomePageView.axaml
+++ b/src/Asv.Avalonia/Shell/Pages/Home/HomePageView.axaml
@@ -10,10 +10,13 @@
     <Design.DataContext>
         <avalonia1:HomePageViewModel/>
     </Design.DataContext>
+    <UserControl.Resources>
+        <avalonia1:VersionConverter x:Key="VersionConverter"/>
+    </UserControl.Resources>
     <DockPanel Margin="40,40,40,0">
         <TextBlock FontWeight="Thin" FontSize="60" DockPanel.Dock="Top" >
             <Run Text="{Binding AppInfo.Name}"/>
-            <Run FontSize="35" Foreground="{DynamicResource  ButtonForegroundDisabled}" Text="{Binding AppInfo.Version}"/>
+            <Run FontSize="35" Foreground="{DynamicResource  ButtonForegroundDisabled}" Text="{Binding AppInfo.Version, Converter={StaticResource VersionConverter}}"/>
         </TextBlock>
         <TextBlock Margin="0,-5,0,10" FontWeight="ExtraLight" FontSize="26" Foreground="{DynamicResource  ButtonForegroundDisabled}" DockPanel.Dock="Top" 
                    Text="{Binding AppInfo.Description}"/>


### PR DESCRIPTION
I create a VersionConverter that removes the '+' and the numbers coming at the end from the version strings

Integrated VersionConverter into HomePageView.axaml bindings.

Asana: https://app.asana.com/1/1200746044236722/project/1203851531040615/task/1209604202284291?focus=true