### PR TITLE
feat(asv-example): migrate packet viewer from Asv.Drones

### DIFF
--- a/src/Asv.Avalonia.Example/Asv.Avalonia.Example.csproj
+++ b/src/Asv.Avalonia.Example/Asv.Avalonia.Example.csproj
@@ -69,5 +69,9 @@
       </Compile>
     </ItemGroup>
 
+    <ItemGroup>
+      <UpToDateCheckInput Remove="Pages\PacketViewer\Dialogs\SeparatorViewDialog.axaml" />
+    </ItemGroup>
+
    
 </Project>

--- a/src/Asv.Avalonia.Example/Converters/DefaultPacketConverter.cs
+++ b/src/Asv.Avalonia.Example/Converters/DefaultPacketConverter.cs
@@ -1,0 +1,58 @@
+using System;
+using System.Composition;
+using Asv.Mavlink;
+using Newtonsoft.Json;
+
+namespace Asv.Avalonia.Example.Converters;
+
+/// <summary>
+/// Default packet converter. Used when there is no specialized converter for some packet type.
+/// </summary>
+[Export(typeof(IPacketConverter))]
+public class DefaultPacketConverter : IPacketConverter
+{
+    public int Order => int.MaxValue;
+
+    public bool CanConvert(MavlinkMessage packet)
+    {
+        if (packet == null)
+        {
+            throw new ArgumentException("Incoming packet was not initialized!");
+        }
+
+        return true;
+    }
+
+    public string Convert(
+        MavlinkMessage packet,
+        PacketFormatting formatting = PacketFormatting.None
+    )
+    {
+        if (packet == null)
+        {
+            throw new ArgumentException("Incoming packet was not initialized!");
+        }
+
+        if (!CanConvert(packet))
+        {
+            throw new ArgumentException("Converter can not convert incoming packet!");
+        }
+
+        string result = string.Empty;
+
+        if (formatting == PacketFormatting.None)
+        {
+            result = JsonConvert.SerializeObject(packet.GetPayload(), Formatting.None);
+        }
+        else if (formatting == PacketFormatting.Indented)
+        {
+            result = JsonConvert.SerializeObject(packet.GetPayload(), Formatting.Indented);
+        }
+        else
+        {
+            throw new ArgumentException("Wrong packet formatting!");
+        }
+
+        return result;
+    }
+}

--- a/src/Asv.Avalonia.Example/Converters/IPacketConverter.cs
+++ b/src/Asv.Avalonia.Example/Converters/IPacketConverter.cs
@@ -1,0 +1,50 @@
+using Asv.IO;
+using Asv.Mavlink;
+
+namespace Asv.Avalonia.Example.Converters;
+
+/// <summary>
+/// Represents the formatting options for packet data.
+/// </summary>
+public enum PacketFormatting
+{
+    /// <summary>
+    /// One-line formatting
+    /// </summary>
+    None,
+
+    /// <summary>
+    /// Represents the formatting options for packet content.
+    /// </summary>
+    Indented,
+}
+
+/// <summary>
+/// Represents an interface for converting packet payloads to string representation.
+/// </summary>
+public interface IPacketConverter
+{
+    /// <summary>
+    /// Gets the order of the converter in the list of all converters.
+    /// </summary>
+    int Order { get; }
+
+    /// <summary>
+    /// Checks whether the converter can convert the payload of a given packet.
+    /// </summary>
+    /// <param name="packet">The packet to convert</param>
+    /// <returns>Returns true if the converter can convert the payload, false otherwise</returns>
+    bool CanConvert(MavlinkMessage packet);
+
+    /// <summary>
+    /// Converts packet's payload to string.
+    /// </summary>
+    /// <param name="packet">The packet to convert.</param>
+    /// <param name="formatting">
+    /// The formatting of the result string. This is optional and is used to create packets with special formatting. The default value is 'None'.
+    /// </param>
+    /// <returns>
+    /// A string representation of the packet.
+    /// </returns>
+    string Convert(MavlinkMessage packet, PacketFormatting formatting = PacketFormatting.None);
+}

--- a/src/Asv.Avalonia.Example/Pages/PacketViewer/Command/OpenPacketViewer.cs
+++ b/src/Asv.Avalonia.Example/Pages/PacketViewer/Command/OpenPacketViewer.cs
@@ -1,0 +1,25 @@
+using System.Composition;
+
+namespace Asv.Avalonia.Example.PacketViewer.Command;
+
+[ExportCommand]
+[method: ImportingConstructor]
+public class OpenPacketViewerCommand(INavigationService nav)
+    : OpenPageCommandBase(PacketViewerViewModel.PageId, nav)
+{
+    #region Static
+    public const string Id = $"{BaseId}.open.{PacketViewerViewModel.PageId}";
+
+    public static readonly ICommandInfo StaticInfo = new CommandInfo
+    {
+        Id = Id,
+        Name = RS.PacketViewerViewDockPanelText,
+        Description = RS.PacketViewer_Open,
+        Icon = PacketViewerViewModel.PageIcon,
+        DefaultHotKey = null,
+        Source = SystemModule.Instance,
+    };
+
+    #endregion
+    public override ICommandInfo Info => StaticInfo;
+}

--- a/src/Asv.Avalonia.Example/Pages/PacketViewer/Dialogs/SeparatorView.axaml
+++ b/src/Asv.Avalonia.Example/Pages/PacketViewer/Dialogs/SeparatorView.axaml
@@ -1,0 +1,28 @@
+<UserControl xmlns="https://github.com/avaloniaui"
+             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+             xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+             xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+             xmlns:packetViewer="clr-namespace:Asv.Avalonia.Example.PacketViewer.Dialogs"
+             xmlns:example="clr-namespace:Asv.Avalonia.Example"
+             mc:Ignorable="d" Width="400" Height="200"
+             x:CompileBindings="True"
+             x:DataType="packetViewer:SeparatorViewModel"
+             x:Class="Asv.Avalonia.Example.PacketViewer.Dialogs.SeparatorView">
+    <Design.DataContext>
+        <packetViewer:SeparatorViewModel />
+    </Design.DataContext>
+    <Panel>
+        <StackPanel Spacing="10" Margin="10">
+            <TextBlock Text="Путь к файлу" FontSize="18" FontWeight="Bold"/>
+            <TextBox Text="{CompiledBinding FilePath.Value, Mode=TwoWay}" 
+                     Watermark="C:/Path/To/File.csv"/>
+            <TextBlock Text="Разделитель:" FontSize="16"/>
+            <RadioButton Content="{x:Static example:RS.PacketViewerViewModel_SeparatorDialog_Semicolon}"
+                         IsChecked="{CompiledBinding IsSemicolon.Value, Mode=TwoWay}" />
+            <RadioButton Content="{x:Static example:RS.PacketViewerViewModel_SeparatorDialog_Coma}"
+                         IsChecked="{CompiledBinding IsComa.Value, Mode=TwoWay}" />
+            <RadioButton Content="{x:Static example:RS.PacketViewerViewModel_SeparatorDialog_Tab}"
+                         IsChecked="{CompiledBinding IsTab.Value, Mode=TwoWay}" />
+        </StackPanel>
+    </Panel>
+</UserControl>

--- a/src/Asv.Avalonia.Example/Pages/PacketViewer/Dialogs/SeparatorView.axaml.cs
+++ b/src/Asv.Avalonia.Example/Pages/PacketViewer/Dialogs/SeparatorView.axaml.cs
@@ -1,0 +1,12 @@
+using Avalonia.Controls;
+
+namespace Asv.Avalonia.Example.PacketViewer.Dialogs;
+
+[ExportViewFor(typeof(SeparatorViewModel))]
+public partial class SeparatorView : UserControl
+{
+    public SeparatorView()
+    {
+        InitializeComponent();
+    }
+}

--- a/src/Asv.Avalonia.Example/Pages/PacketViewer/Dialogs/SeparatorViewModel.cs
+++ b/src/Asv.Avalonia.Example/Pages/PacketViewer/Dialogs/SeparatorViewModel.cs
@@ -1,0 +1,179 @@
+using System;
+using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
+using Asv.Common;
+using Avalonia.Controls;
+using Microsoft.Extensions.Logging;
+using Microsoft.IO;
+using ObservableCollections;
+using R3;
+
+namespace Asv.Avalonia.Example.PacketViewer.Dialogs;
+
+public class SeparatorViewModel : DialogViewModelBase
+{
+    public const string ViewModelId = "packet_viewer.separator.dialog";
+
+    private readonly ILogger _logger;
+    private readonly ObservableList<PacketMessageViewModel> _packetsList;
+
+    public SeparatorViewModel()
+        : base(ViewModelId)
+    {
+        FilePath = new BindableReactiveProperty<string>(string.Empty);
+        IsSemicolon = new BindableReactiveProperty<bool>(true);
+        IsComa = new BindableReactiveProperty<bool>(false);
+        IsTab = new BindableReactiveProperty<bool>(false);
+    }
+
+    public SeparatorViewModel(
+        ILoggerFactory loggerFactory,
+        ObservableList<PacketMessageViewModel> packetsList
+    )
+        : base(ViewModelId)
+    {
+        _logger = loggerFactory.CreateLogger<SeparatorViewModel>();
+        _packetsList = packetsList ?? throw new ArgumentNullException(nameof(packetsList));
+
+        FilePath = new BindableReactiveProperty<string>(string.Empty);
+        IsSemicolon = new BindableReactiveProperty<bool>(true);
+        IsComa = new BindableReactiveProperty<bool>(false);
+        IsTab = new BindableReactiveProperty<bool>(false);
+
+        _sub1 = FilePath.EnableValidation(
+            value =>
+            {
+                if (string.IsNullOrWhiteSpace(value))
+                {
+                    return ValueTask.FromResult<ValidationResult>(
+                        new Exception("Путь к файлу обязателен")
+                    );
+                }
+
+                if (!Directory.Exists(Path.GetDirectoryName(value)))
+                {
+                    return ValueTask.FromResult<ValidationResult>(
+                        new Exception("Указанная папка не существует")
+                    );
+                }
+
+                return ValidationResult.Success;
+            },
+            this,
+            true
+        );
+
+        _sub2 = IsSemicolon.Subscribe(value =>
+        {
+            if (value)
+            {
+                IsComa.Value = false;
+                IsTab.Value = false;
+            }
+        });
+
+        _sub3 = IsComa.Subscribe(value =>
+        {
+            if (value)
+            {
+                IsSemicolon.Value = false;
+                IsTab.Value = false;
+            }
+        });
+
+        _sub4 = IsTab.Subscribe(value =>
+        {
+            if (value)
+            {
+                IsSemicolon.Value = false;
+                IsComa.Value = false;
+            }
+        });
+    }
+
+    public BindableReactiveProperty<string> FilePath { get; }
+    public BindableReactiveProperty<bool> IsSemicolon { get; }
+    public BindableReactiveProperty<bool> IsComa { get; }
+    public BindableReactiveProperty<bool> IsTab { get; }
+
+    private async Task ExportToCsvAsync(IProgress<double> progress, CancellationToken cancel)
+    {
+        try
+        {
+            var separator = ";";
+            var shieldSymbol = ",";
+
+            if (IsComa.Value)
+            {
+                separator = ",";
+                shieldSymbol = ";";
+            }
+            else if (IsTab.Value)
+            {
+                separator = "\t";
+                shieldSymbol = ",";
+            }
+
+            var fullPath = FilePath.Value;
+
+            CsvHelper.SaveToCsv(
+                _packetsList,
+                fullPath,
+                separator,
+                shieldSymbol,
+                new CsvColumn<PacketMessageViewModel>("Date", x => x.DateTime.ToString("G")),
+                new CsvColumn<PacketMessageViewModel>("Type", x => x.Type),
+                new CsvColumn<PacketMessageViewModel>("Source", x => x.Source),
+                new CsvColumn<PacketMessageViewModel>("Message", x => x.Message)
+            );
+
+            _logger.LogInformation("Файл сохранен по пути: {0}", fullPath);
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "Ошибка при сохранении файла по пути: {0}", FilePath.Value);
+            throw;
+        }
+    }
+
+    public void ApplyDialog(ContentDialog dialog)
+    {
+        ArgumentNullException.ThrowIfNull(dialog);
+
+        _sub5 = IsValid.Subscribe(isValid =>
+        {
+            dialog.IsPrimaryButtonEnabled = isValid;
+        });
+
+        dialog.PrimaryButtonCommand = new ReactiveCommand<IProgress<double>>(
+            async (p, ct) => await ExportToCsvAsync(p, ct)
+        );
+    }
+
+    public override IEnumerable<IRoutable> GetRoutableChildren() => [];
+
+    #region Dispose
+
+    private readonly IDisposable _sub1;
+    private readonly IDisposable _sub2;
+    private readonly IDisposable _sub3;
+    private readonly IDisposable _sub4;
+    private IDisposable _sub5;
+
+    protected override void Dispose(bool isDisposing)
+    {
+        if (isDisposing)
+        {
+            _sub1.Dispose();
+            _sub2.Dispose();
+            _sub3.Dispose();
+            _sub4.Dispose();
+            _sub5?.Dispose();
+        }
+
+        base.Dispose(isDisposing);
+    }
+
+    #endregion
+}

--- a/src/Asv.Avalonia.Example/Pages/PacketViewer/HomePacketViewerExtension.cs
+++ b/src/Asv.Avalonia.Example/Pages/PacketViewer/HomePacketViewerExtension.cs
@@ -1,0 +1,16 @@
+using Asv.Avalonia.Example.PacketViewer.Command;
+using Asv.Common;
+using R3;
+
+namespace Asv.Avalonia.Example.PacketViewer;
+
+[ExportExtensionFor<IHomePage>]
+public class HomePacketViewerExtension : IExtensionFor<IHomePage>
+{
+    public void Extend(IHomePage context, CompositeDisposable contextDispose)
+    {
+        context.Tools.Add(
+            OpenPacketViewerCommand.StaticInfo.CreateAction().DisposeItWith(contextDispose)
+        );
+    }
+}

--- a/src/Asv.Avalonia.Example/Pages/PacketViewer/PacketFilterViewModel.cs
+++ b/src/Asv.Avalonia.Example/Pages/PacketViewer/PacketFilterViewModel.cs
@@ -1,0 +1,66 @@
+using System;
+using System.Threading;
+using Asv.Avalonia;
+using Asv.Avalonia.Example.PacketViewer;
+using Asv.Common;
+using R3;
+
+public class PacketFilterViewModel : IDisposable
+{
+    private volatile int _cnt;
+    private readonly IncrementalRateCounter _packetRate = new(3);
+    private readonly IUnit _unit;
+    private readonly CompositeDisposable _disposables = new();
+
+    public BindableReactiveProperty<string> Type { get; }
+    public BindableReactiveProperty<string> Source { get; }
+    public BindableReactiveProperty<string> MessageRateText { get; }
+    public BindableReactiveProperty<bool> IsChecked { get; }
+
+    public PacketFilterViewModel()
+        : this(null!, NullUnitService.Instance)
+    {
+        DesignTime.ThrowIfNotDesignMode();
+    }
+
+    public PacketFilterViewModel(PacketMessageViewModel pkt, IUnitService unitService)
+    {
+        Type = new BindableReactiveProperty<string>(string.Empty);
+        Source = new BindableReactiveProperty<string>(string.Empty);
+        MessageRateText = new BindableReactiveProperty<string>(string.Empty);
+        IsChecked = new BindableReactiveProperty<bool>(false);
+        _disposables.Add(Type);
+        _disposables.Add(Source);
+        _disposables.Add(MessageRateText);
+        _disposables.Add(IsChecked);
+        _unit =
+            unitService[VelocityBase.Id]
+            ?? throw new ArgumentException(
+                $"Unit with ID '{VelocityBase.Id}' not found in IUnitService"
+            );
+        UpdateRates();
+
+        if (pkt != null)
+        {
+            Type.Value = pkt.Type;
+            Source.Value = pkt.Source;
+            IsChecked.Value = true;
+        }
+    }
+
+    public void UpdateRates()
+    {
+        Interlocked.Increment(ref _cnt);
+    }
+
+    public void UpdateRateText()
+    {
+        var packetRate = Math.Round(_packetRate.Calculate(_cnt), 1);
+        MessageRateText.Value = _unit.InternationalSystemUnit.PrintWithUnits(packetRate);
+    }
+
+    public void Dispose()
+    {
+        _disposables.Dispose();
+    }
+}

--- a/src/Asv.Avalonia.Example/Pages/PacketViewer/PacketMessageViewModel.cs
+++ b/src/Asv.Avalonia.Example/Pages/PacketViewer/PacketMessageViewModel.cs
@@ -1,0 +1,52 @@
+using System;
+using Asv.Avalonia.Example.Converters;
+using Asv.IO;
+using Asv.Mavlink;
+using Avalonia;
+using R3;
+using PacketFormatting = Asv.Avalonia.Example.Converters.PacketFormatting;
+
+namespace Asv.Avalonia.Example.PacketViewer;
+
+public class PacketMessageViewModel : AvaloniaObject
+{
+    public DateTime DateTime { get; set; }
+    public string Source { get; set; }
+    public int Size { get; set; }
+    public string Message { get; set; }
+    public string Type { get; set; }
+
+    private bool _highlight;
+
+    public static readonly DirectProperty<PacketMessageViewModel, bool> HighlightProperty =
+        AvaloniaProperty.RegisterDirect<PacketMessageViewModel, bool>(
+            nameof(Highlight),
+            o => o.Highlight,
+            (o, v) => o.Highlight = v
+        );
+
+    public bool Highlight
+    {
+        get => _highlight;
+        set => SetAndRaise(HighlightProperty, ref _highlight, value);
+    }
+
+    public PacketMessageViewModel()
+    {
+        DesignTime.ThrowIfNotDesignMode();
+    }
+
+    public PacketMessageViewModel(MavlinkMessage packet, IPacketConverter converter)
+    {
+        DateTime = DateTime.Now;
+        Source = $"[{packet.SystemId},{packet.ComponentId}]";
+        Message = $"[{packet.Sequence:000}] {converter.Convert(packet)}";
+        Description = converter.Convert(packet, PacketFormatting.Indented);
+        Type = packet.Name;
+        Id = Guid.NewGuid();
+        Size = packet.GetByteSize();
+    }
+
+    public Guid Id { get; }
+    public string Description { get; }
+}

--- a/src/Asv.Avalonia.Example/Pages/PacketViewer/PacketViewerView.axaml
+++ b/src/Asv.Avalonia.Example/Pages/PacketViewer/PacketViewerView.axaml
@@ -1,0 +1,156 @@
+<UserControl xmlns="https://github.com/avaloniaui"
+             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+             xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+             xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+             xmlns:avalonia="clr-namespace:Material.Icons.Avalonia;assembly=Material.Icons.Avalonia"
+             xmlns:packetViewer="clr-namespace:Asv.Avalonia.Example.PacketViewer"
+             xmlns:gui1="clr-namespace:Asv.Avalonia.Example"
+             mc:Ignorable="d" d:DesignWidth="800" d:DesignHeight="450"
+             x:DataType="packetViewer:PacketViewerViewModel"
+             x:Class="Asv.Avalonia.Example.PacketViewerView">
+    <UserControl.Styles>
+        <Style Selector="ToggleButton ContentPresenter.tbchecked">
+            <Setter Property="IsVisible" Value="False" />
+        </Style>
+        <Style Selector="ToggleButton:checked ContentPresenter.tbchecked">
+            <Setter Property="IsVisible" Value="True" />
+        </Style>
+        <Style Selector="ToggleButton ContentPresenter.tbunchecked">
+            <Setter Property="IsVisible" Value="True" />
+        </Style>
+        <Style Selector="ToggleButton:checked ContentPresenter.tbunchecked">
+            <Setter Property="IsVisible" Value="False" />
+        </Style>
+        <Style Selector="Button.saveButton">
+            <Setter Property="Opacity" Value="1.0" />
+        </Style>
+        <Style Selector="Button.saveButton:disabled">
+            <Setter Property="Opacity" Value="0.3" />
+        </Style>
+    </UserControl.Styles>
+    <Design.DataContext>
+        <packetViewer:PacketViewerViewModel />
+    </Design.DataContext>
+    <Grid ColumnDefinitions="* Auto" RowDefinitions="Auto *" Margin="8">
+        <DockPanel Grid.Row="0" Grid.ColumnSpan="2">
+            <Button DockPanel.Dock="Right" Grid.Row="0" Margin="5 0 0 0" HorizontalAlignment="Stretch"
+                    VerticalAlignment="Stretch" Command="{Binding ExportToCsv}"
+                    Content="{avalonia:MaterialIconExt ContentSave}"
+                    ToolTip.Tip="{x:Static gui1:RS.PacketViewerView_Save}"
+                    IsEnabled="{Binding IsPause.Value}"
+                    Classes="saveButton" />
+            <Button DockPanel.Dock="Right" Margin="5 0 0 0" HorizontalAlignment="Stretch" VerticalAlignment="Stretch"
+                    Command="{CompiledBinding ClearAll}" Content="{avalonia:MaterialIconExt Bin}"
+                    ToolTip.Tip="{x:Static gui1:RS.PacketViewerView_ClearAll}" />
+            <ToggleButton DockPanel.Dock="Right" Margin="5 0 5 0" HorizontalAlignment="Stretch"
+                          VerticalAlignment="Stretch" IsChecked="{Binding IsPause.Value, Mode=TwoWay}"
+                          ToolTip.Tip="{x:Static gui1:RS.PacketViewerView_PlayPause}">
+                <Panel>
+                    <ContentPresenter Content="{avalonia:MaterialIconExt Play}" Classes="tbchecked" />
+                    <ContentPresenter Content="{avalonia:MaterialIconExt Pause}" Classes="tbunchecked" />
+                </Panel>
+            </ToggleButton>
+           <TextBox DockPanel.Dock="Right" MinWidth="200" Text="{Binding SearchText.Value, Mode=TwoWay}">
+                <TextBox.Styles>
+                    <Style Selector="TextBox">
+                        <Setter Property="InnerRightContent">
+                            <Template>
+                                <Button Content="X" Background="Transparent" BorderBrush="{x:Null}"
+                                        Command="{Binding $parent[TextBox].Clear}" />
+                            </Template>
+                        </Setter>
+                    </Style>
+                </TextBox.Styles>
+            </TextBox>
+            <avalonia:MaterialIcon DockPanel.Dock="Left" Height="30" Width="30" Kind="Package" />
+        </DockPanel>
+        
+        <ListBox ScrollViewer.HorizontalScrollBarVisibility="Visible" Grid.Column="0" Grid.Row="1" Margin="0,0,8,0"
+                 SelectedItem="{Binding SelectedPacket.Value}" ItemsSource="{Binding Packets}" Grid.IsSharedSizeScope="True">
+            <ListBox.Styles>
+                <Style Selector="ListBoxItem">
+                    <Setter Property="MinHeight" Value="25"></Setter>
+                </Style>
+            </ListBox.Styles>
+            <ItemsControl.ItemTemplate>
+                <DataTemplate>
+                    <Grid ToolTip.Tip="{Binding Description}">
+                        <Grid.ColumnDefinitions>
+                            <ColumnDefinition SharedSizeGroup="Date" Width="Auto" />
+                            <ColumnDefinition SharedSizeGroup="Source" Width="Auto" />
+                            <ColumnDefinition SharedSizeGroup="Size" Width="Auto" />
+                            <ColumnDefinition SharedSizeGroup="Type" Width="Auto" />
+                            <ColumnDefinition SharedSizeGroup="Message" Width="Auto" />
+                        </Grid.ColumnDefinitions>
+                        <Panel Grid.ColumnSpan="4" Background="#5779C1" IsVisible="{Binding Highlight}" />
+                        <TextBlock FontFamily="Consolas" Margin="5,0" Grid.Column="0"
+                                   Text="{Binding DateTime, StringFormat={}{0:hh:mm:ss.fff}}" />
+                        <TextBlock FontFamily="Consolas" Margin="5,0" Grid.Column="1" Text="{Binding Source}" />
+                        <TextBlock FontFamily="Consolas" Margin="5,0" Grid.Column="2" Text="{Binding Size}" />
+                        <TextBlock FontFamily="Consolas" Margin="5,0" Grid.Column="3" Text="{Binding Type}" />
+                        <TextBlock FontFamily="Consolas" Margin="5,0" Grid.Column="4" Text="{Binding Message}" />
+                    </Grid>
+                </DataTemplate>
+            </ItemsControl.ItemTemplate>
+        </ListBox>
+
+        <StackPanel Grid.Column="1" Grid.Row="1" MinWidth="340" Spacing="4">
+            <Expander Header="{x:Static gui1:RS.PacketViewer_Expander_MessageSources}">
+                <StackPanel Spacing="4">
+                    <CheckBox HorizontalAlignment="Left" IsChecked="True" 
+                             Checked="OnSourcesChecked" Unchecked="OnSourcesUnchecked" 
+                             Content="{x:Static gui1:RS.PacketViewerView_CheckAll}" />
+                    <ListBox HorizontalAlignment="Stretch" x:Name="SourceFilters"
+                             ItemsSource="{Binding FiltersBySource}" Grid.IsSharedSizeScope="True">
+                        <ItemsControl.ItemTemplate>
+                            <DataTemplate>
+                                <Grid>
+                                    <Grid.ColumnDefinitions>
+                                        <ColumnDefinition />
+                                        <ColumnDefinition Width="Auto" SharedSizeGroup="Rate" />
+                                    </Grid.ColumnDefinitions>
+                                    <CheckBox VerticalAlignment="Center" IsChecked="{Binding IsChecked.Value, Mode=TwoWay}"
+                                              Padding="4 2 0 0">
+                                        <CheckBox.Content>
+                                            <TextBlock VerticalAlignment="Center" Text="{Binding Source.Value}" />
+                                        </CheckBox.Content>
+                                    </CheckBox>
+                                    <TextBlock Grid.Column="1" VerticalAlignment="Center"
+                                               Text="{Binding MessageRateText.Value}" />
+                                </Grid>
+                            </DataTemplate>
+                        </ItemsControl.ItemTemplate>
+                    </ListBox>
+                </StackPanel>
+            </Expander>
+            <Expander Header="{x:Static gui1:RS.PacketViewer_Expander_MessageTypes}">
+                <StackPanel Spacing="4">
+                    <CheckBox HorizontalAlignment="Left" IsChecked="True" 
+                             Checked="OnTypesChecked" Unchecked="OnTypesUnchecked" 
+                             Content="{x:Static gui1:RS.PacketViewerView_CheckAll}" />
+                    <ListBox HorizontalAlignment="Stretch" x:Name="TypeFilters" 
+                             ItemsSource="{Binding FiltersByType}" Grid.IsSharedSizeScope="True">
+                        <ItemsControl.ItemTemplate>
+                            <DataTemplate>
+                                <Grid>
+                                    <Grid.ColumnDefinitions>
+                                        <ColumnDefinition />
+                                        <ColumnDefinition Width="Auto" SharedSizeGroup="Rate" />
+                                    </Grid.ColumnDefinitions>
+                                    <CheckBox VerticalAlignment="Center" IsChecked="{Binding IsChecked.Value, Mode=TwoWay}"
+                                              Padding="4 2 0 0">
+                                        <CheckBox.Content>
+                                            <TextBlock Text="{Binding Type.Value}" />
+                                        </CheckBox.Content>
+                                    </CheckBox>
+                                    <TextBlock Grid.Column="1" VerticalAlignment="Center"
+                                               Text="{Binding MessageRateText.Value}" />
+                                </Grid>
+                            </DataTemplate>
+                        </ItemsControl.ItemTemplate>
+                    </ListBox>
+                </StackPanel>
+            </Expander>
+        </StackPanel>
+    </Grid>
+</UserControl>

--- a/src/Asv.Avalonia.Example/Pages/PacketViewer/PacketViewerView.axaml.cs
+++ b/src/Asv.Avalonia.Example/Pages/PacketViewer/PacketViewerView.axaml.cs
@@ -1,0 +1,61 @@
+using System.Linq;
+using Asv.Avalonia.Example.PacketViewer;
+using Avalonia;
+using Avalonia.Controls;
+using Avalonia.Interactivity;
+using Avalonia.Markup.Xaml;
+
+namespace Asv.Avalonia.Example;
+
+[ExportViewFor(typeof(PacketViewerViewModel))]
+public partial class PacketViewerView : UserControl
+{
+    public PacketViewerView()
+    {
+        InitializeComponent();
+    }
+
+    private void OnSourcesChecked(object? sender, RoutedEventArgs e)
+    {
+        if (DataContext is PacketViewerViewModel vm)
+        {
+            foreach (var filter in vm.FiltersBySource)
+            {
+                filter.IsChecked.Value = true;
+            }
+        }
+    }
+
+    private void OnSourcesUnchecked(object? sender, RoutedEventArgs e)
+    {
+        if (DataContext is PacketViewerViewModel vm)
+        {
+            foreach (var filter in vm.FiltersBySource)
+            {
+                filter.IsChecked.Value = false;
+            }
+        }
+    }
+
+    private void OnTypesChecked(object? sender, RoutedEventArgs e)
+    {
+        if (DataContext is PacketViewerViewModel vm)
+        {
+            foreach (var filter in vm.FiltersByType)
+            {
+                filter.IsChecked.Value = true;
+            }
+        }
+    }
+
+    private void OnTypesUnchecked(object? sender, RoutedEventArgs e)
+    {
+        if (DataContext is PacketViewerViewModel vm)
+        {
+            foreach (var filter in vm.FiltersByType)
+            {
+                filter.IsChecked.Value = false;
+            }
+        }
+    }
+}

--- a/src/Asv.Avalonia.Example/Pages/PacketViewer/PacketViewerViewModel.cs
+++ b/src/Asv.Avalonia.Example/Pages/PacketViewer/PacketViewerViewModel.cs
@@ -1,0 +1,296 @@
+using System;
+using System.Collections.Generic;
+using System.Composition;
+using System.IO;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using Asv.Avalonia.Example.Converters;
+using Asv.Avalonia.Example.PacketViewer.Dialogs;
+using Asv.Avalonia.IO;
+using Asv.Common;
+using Asv.Mavlink;
+using Avalonia.Threading;
+using Material.Icons;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Logging.Abstractions;
+using ObservableCollections;
+using R3;
+
+namespace Asv.Avalonia.Example.PacketViewer;
+
+[ExportPage(PageId)]
+public class PacketViewerViewModel : PageViewModel<PacketViewerViewModel>
+{
+    public const string PageId = "packet_viewer";
+    public const MaterialIconKind PageIcon = MaterialIconKind.Package;
+    private readonly ILoggerFactory _loggerFactory;
+    private readonly INavigationService _navigationService;
+    private readonly ILogger<PacketViewerViewModel> _logger;
+    private readonly IAppPath _app;
+    private readonly IUnitService _unit;
+    private readonly IDeviceManager _deviceManager;
+    private readonly IEnumerable<IPacketConverter> _converters;
+    private readonly IDialogService _dialogService;
+    private readonly CompositeDisposable _disposables = new();
+    public const int MaxPacketSize = 1000;
+
+    private readonly ObservableList<PacketMessageViewModel> _packetsList = new();
+    private readonly ObservableList<PacketFilterViewModel> _filtersBySourceList = new();
+    private readonly ObservableList<PacketFilterViewModel> _filtersByTypeList = new();
+    private NotifyCollectionChangedSynchronizedViewList<PacketMessageViewModel> _filteredPackets;
+
+    public BindableReactiveProperty<bool> IsPause { get; } = new(false);
+    public BindableReactiveProperty<string> SearchText { get; } = new(string.Empty);
+    public BindableReactiveProperty<PacketMessageViewModel?> SelectedPacket { get; } = new();
+
+    public INotifyCollectionChangedSynchronizedViewList<PacketMessageViewModel> Packets =>
+        _filteredPackets;
+    public ObservableList<PacketFilterViewModel> FiltersBySource => _filtersBySourceList;
+    public ObservableList<PacketFilterViewModel> FiltersByType => _filtersByTypeList;
+
+    public PacketViewerViewModel()
+        : this(
+            DesignTime.CommandService,
+            NullAppPath.Instance,
+            NullLoggerFactory.Instance,
+            NullUnitService.Instance,
+            null!,
+            NullDeviceManager.Instance,
+            null!,
+            NullNavigationService.Instance
+        )
+    {
+        DesignTime.ThrowIfNotDesignMode();
+        Title.OnNext(RS.PacketViewerViewDockPanelText);
+        _packetsList.AddRange(
+            new[]
+            {
+                new PacketMessageViewModel
+                {
+                    DateTime = DateTime.Now,
+                    Source = "[1,1]",
+                    Type = "HEARTBEAT",
+                    Message = "Test message 1",
+                },
+                new PacketMessageViewModel
+                {
+                    DateTime = DateTime.Now,
+                    Source = "[1,1]",
+                    Type = "HEARTBEAT",
+                    Message = "Test message 2",
+                },
+                new PacketMessageViewModel
+                {
+                    DateTime = DateTime.Now,
+                    Source = "[1,1]",
+                    Type = "HEARTBEAT",
+                    Message = "Test message 3",
+                },
+            }
+        );
+    }
+
+    [ImportingConstructor]
+    public PacketViewerViewModel(
+        ICommandService cmd,
+        IAppPath app,
+        ILoggerFactory logFactory,
+        IUnitService unit,
+        [ImportMany] IEnumerable<IPacketConverter> converters,
+        IDeviceManager deviceManager,
+        IDialogService service,
+        INavigationService navigationService
+    )
+        : base(PageId, cmd)
+    {
+        Title.OnNext(RS.PacketViewerViewDockPanelText);
+        _app = app;
+        _logger = logFactory.CreateLogger<PacketViewerViewModel>();
+        _loggerFactory = logFactory;
+        _unit = unit;
+        _converters = converters;
+        _deviceManager = deviceManager;
+        _dialogService = service;
+        _navigationService = navigationService;
+
+        ExportToCsv = new ReactiveCommand(ExportToCsvAsync);
+        ClearAll = new ReactiveCommand(ClearAllAsync);
+
+        _deviceManager
+            .Router.OnRxMessage.Where(_ => !IsPause.Value)
+            .ThrottleFirst(TimeSpan.FromMilliseconds(100))
+            .Select(packet => ConvertPacketsAndUpdateFiltersAsync((MavlinkMessage)packet))
+            .Subscribe(async packets =>
+            {
+                _logger.LogInformation($"Received {packets.Result.Count} packets");
+                if (_packetsList.Count + packets.Result.Count > MaxPacketSize)
+                {
+                    var toRemove = _packetsList.Count + packets.Result.Count - MaxPacketSize;
+                    _packetsList.RemoveRange(0, toRemove);
+                }
+
+                _packetsList.AddRange(packets.Result);
+            })
+            .AddTo(_disposables);
+
+        Observable
+            .Timer(TimeSpan.FromSeconds(1), TimeSpan.FromSeconds(1))
+            .Subscribe(_ =>
+            {
+                Dispatcher.UIThread.InvokeAsync(() =>
+                {
+                    foreach (var filter in _filtersBySourceList)
+                    {
+                        filter.UpdateRateText();
+                    }
+
+                    foreach (var filter in _filtersByTypeList)
+                    {
+                        filter.UpdateRateText();
+                    }
+                });
+            })
+            .AddTo(_disposables);
+
+        SelectedPacket
+            .WhereNotNull()
+            .Subscribe(selectedPacket =>
+            {
+                foreach (var item in _packetsList)
+                {
+                    item.Highlight = item.Type == selectedPacket.Type;
+                }
+            })
+            .AddTo(_disposables);
+
+        _filteredPackets = _packetsList.CreateView(x => x).ToNotifyCollectionChanged();
+
+        SetupFilteringAsync().GetAwaiter().GetResult();
+
+        _filtersBySourceList
+            .ObserveChanged()
+            .Subscribe(_ =>
+                _logger.LogInformation(
+                    $"FiltersBySource updated, count: {_filtersBySourceList.Count}"
+                )
+            )
+            .AddTo(_disposables);
+        _filtersByTypeList
+            .ObserveChanged()
+            .Subscribe(_ =>
+                _logger.LogInformation($"FiltersByType updated, count: {_filtersByTypeList.Count}")
+            )
+            .AddTo(_disposables);
+    }
+
+    private Task SetupFilteringAsync()
+    {
+        var view = _packetsList.CreateView(x => x);
+        _filteredPackets = view.ToNotifyCollectionChanged();
+
+        Observable
+            .Merge(
+                _packetsList.ObserveChanged().Select(_ => Unit.Default),
+                _filtersBySourceList.ObserveChanged().Select(_ => Unit.Default),
+                _filtersByTypeList.ObserveChanged().Select(_ => Unit.Default),
+                SearchText.Select(_ => Unit.Default),
+                SelectedPacket.Select(_ => Unit.Default)
+            )
+            .ThrottleFirst(TimeSpan.FromMilliseconds(100))
+            .Subscribe(_ =>
+            {
+                view.AttachFilter(x =>
+                {
+                    var sourceMatch =
+                        _filtersBySourceList.Count == 0
+                        || _filtersBySourceList.Any(f =>
+                            f.IsChecked.Value && f.Source.Value == x.Source
+                        );
+                    var typeMatch =
+                        _filtersByTypeList.Count == 0
+                        || _filtersByTypeList.Any(f => f.IsChecked.Value && f.Type.Value == x.Type);
+                    var searchMatch =
+                        string.IsNullOrEmpty(SearchText.Value)
+                        || x.Message.Contains(SearchText.Value, StringComparison.OrdinalIgnoreCase);
+
+                    return sourceMatch && typeMatch && searchMatch;
+                });
+            })
+            .AddTo(_disposables);
+
+        return Task.CompletedTask;
+    }
+
+    #region Commands
+
+    public ReactiveCommand ExportToCsv { get; }
+
+    public async ValueTask ExportToCsvAsync(Unit unit, CancellationToken cancellationToken) { }
+
+    public ReactiveCommand ClearAll { get; }
+
+    public ValueTask ClearAllAsync(Unit unit, CancellationToken cancellationToken)
+    {
+        _packetsList.Clear();
+        _filtersBySourceList.Clear();
+        _filtersByTypeList.Clear();
+        return ValueTask.CompletedTask;
+    }
+    #endregion
+
+    private async ValueTask<IList<PacketMessageViewModel>> ConvertPacketsAndUpdateFiltersAsync(
+        MavlinkMessage packet
+    )
+    {
+        var result = new List<PacketMessageViewModel>();
+        var converter =
+            _converters.FirstOrDefault(_ => _.CanConvert(packet)) ?? new DefaultPacketConverter();
+        var vm = await Dispatcher.UIThread.InvokeAsync(
+            () => new PacketMessageViewModel(packet, converter)
+        );
+        result.Add(vm);
+        await UpdateFiltersAsync(vm);
+        return result;
+    }
+
+    private async ValueTask UpdateFiltersAsync(PacketMessageViewModel vm)
+    {
+        await Dispatcher.UIThread.InvokeAsync(() =>
+        {
+            var sourceFilter = _filtersBySourceList.FirstOrDefault(x =>
+                x.Source.Value == vm.Source
+            );
+            if (sourceFilter != null)
+            {
+                sourceFilter.UpdateRates();
+            }
+            else
+            {
+                var newSourceFilter = new PacketFilterViewModel(vm, _unit);
+                newSourceFilter.IsChecked.Subscribe(_ => { }).AddTo(_disposables);
+                _filtersBySourceList.Add(newSourceFilter);
+                _logger.LogInformation($"Added new source filter: {vm.Source}");
+            }
+
+            var typeFilter = _filtersByTypeList.FirstOrDefault(x => x.Type.Value == vm.Type);
+            if (typeFilter != null)
+            {
+                typeFilter.UpdateRates();
+            }
+            else
+            {
+                var newTypeFilter = new PacketFilterViewModel(vm, _unit);
+                newTypeFilter.IsChecked.Subscribe(_ => { }).AddTo(_disposables);
+                _filtersByTypeList.Add(newTypeFilter);
+                _logger.LogInformation($"Added new type filter: {vm.Type}");
+            }
+        });
+    }
+
+    public override IEnumerable<IRoutable> GetRoutableChildren() => [];
+
+    protected override void AfterLoadExtensions() { }
+
+    public override IExportInfo Source => SystemModule.Instance;
+}

--- a/src/Asv.Avalonia.Example/RS.Designer.cs
+++ b/src/Asv.Avalonia.Example/RS.Designer.cs
@@ -87,6 +87,132 @@ namespace Asv.Avalonia.Example {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Message sources.
+        /// </summary>
+        public static string PacketViewer_Expander_MessageSources {
+            get {
+                return ResourceManager.GetString("PacketViewer_Expander_MessageSources", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Message types.
+        /// </summary>
+        public static string PacketViewer_Expander_MessageTypes {
+            get {
+                return ResourceManager.GetString("PacketViewer_Expander_MessageTypes", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Open packet viewer.
+        /// </summary>
+        public static string PacketViewer_Open {
+            get {
+                return ResourceManager.GetString("PacketViewer_Open", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Check/Uncheck All.
+        /// </summary>
+        public static string PacketViewerView_CheckAll {
+            get {
+                return ResourceManager.GetString("PacketViewerView_CheckAll", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Clear all packets.
+        /// </summary>
+        public static string PacketViewerView_ClearAll {
+            get {
+                return ResourceManager.GetString("PacketViewerView_ClearAll", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Play/Pause.
+        /// </summary>
+        public static string PacketViewerView_PlayPause {
+            get {
+                return ResourceManager.GetString("PacketViewerView_PlayPause", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Save as CSV.
+        /// </summary>
+        public static string PacketViewerView_Save {
+            get {
+                return ResourceManager.GetString("PacketViewerView_Save", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Packet Viewer.
+        /// </summary>
+        public static string PacketViewerViewDockPanelText {
+            get {
+                return ResourceManager.GetString("PacketViewerViewDockPanelText", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Coma [ , ].
+        /// </summary>
+        public static string PacketViewerViewModel_SeparatorDialog_Coma {
+            get {
+                return ResourceManager.GetString("PacketViewerViewModel_SeparatorDialog_Coma", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Select.
+        /// </summary>
+        public static string PacketViewerViewModel_SeparatorDialog_DialogPrimaryButton {
+            get {
+                return ResourceManager.GetString("PacketViewerViewModel_SeparatorDialog_DialogPrimaryButton", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Cancel.
+        /// </summary>
+        public static string PacketViewerViewModel_SeparatorDialog_DialogSecondaryButton {
+            get {
+                return ResourceManager.GetString("PacketViewerViewModel_SeparatorDialog_DialogSecondaryButton", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Semicolon [ ; ].
+        /// </summary>
+        public static string PacketViewerViewModel_SeparatorDialog_Semicolon {
+            get {
+                return ResourceManager.GetString("PacketViewerViewModel_SeparatorDialog_Semicolon", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Horizontal tabulation [ Tab ].
+        /// </summary>
+        public static string PacketViewerViewModel_SeparatorDialog_Tab {
+            get {
+                return ResourceManager.GetString("PacketViewerViewModel_SeparatorDialog_Tab", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Select the separator.
+        /// </summary>
+        public static string PacketViewerViewModel_SeparatorDialog_Title {
+            get {
+                return ResourceManager.GetString("PacketViewerViewModel_SeparatorDialog_Title", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Remove all pinned parameters.
         /// </summary>
         public static string ParametersEditorPageView_PinsOffButton_ToolTip {
@@ -236,6 +362,24 @@ namespace Asv.Avalonia.Example {
         public static string ParamPageViewModel_DataLossDialog_Title {
             get {
                 return ResourceManager.GetString("ParamPageViewModel_DataLossDialog_Title", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Enter the path.
+        /// </summary>
+        public static string Separator_Path {
+            get {
+                return ResourceManager.GetString("Separator_Path", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Save packet.
+        /// </summary>
+        public static string Separator_Title {
+            get {
+                return ResourceManager.GetString("Separator_Title", resourceCulture);
             }
         }
     }

--- a/src/Asv.Avalonia.Example/RS.resx
+++ b/src/Asv.Avalonia.Example/RS.resx
@@ -78,4 +78,52 @@
     <data name="ParamPageViewModel_DataLossDialog_CloseButtonText" xml:space="preserve">
         <value>Cancel</value>
     </data>
+    <data name="PacketViewerViewModel_SeparatorDialog_Title" xml:space="preserve">
+        <value>Select the separator</value>
+    </data>
+    <data name="PacketViewerViewModel_SeparatorDialog_DialogPrimaryButton" xml:space="preserve">
+        <value>Select</value>
+    </data>
+    <data name="PacketViewerViewModel_SeparatorDialog_DialogSecondaryButton" xml:space="preserve">
+        <value>Cancel</value>
+    </data>
+    <data name="PacketViewerViewModel_SeparatorDialog_Coma" xml:space="preserve">
+        <value>Coma [ , ]</value>
+    </data>
+    <data name="PacketViewerViewModel_SeparatorDialog_Semicolon" xml:space="preserve">
+        <value>Semicolon [ ; ]</value>
+    </data>
+    <data name="PacketViewerView_CheckAll" xml:space="preserve">
+        <value>Check/Uncheck All</value>
+    </data>
+    <data name="PacketViewerView_PlayPause" xml:space="preserve">
+        <value>Play/Pause</value>
+    </data>
+    <data name="PacketViewerView_ClearAll" xml:space="preserve">
+        <value>Clear all packets</value>
+    </data>
+    <data name="PacketViewerView_Save" xml:space="preserve">
+        <value>Save as CSV</value>
+    </data>
+    <data name="PacketViewerViewDockPanelText" xml:space="preserve">
+        <value>Packet Viewer</value>
+    </data>
+    <data name="PacketViewer_Expander_MessageSources" xml:space="preserve">
+        <value>Message sources</value>
+    </data>
+    <data name="PacketViewer_Expander_MessageTypes" xml:space="preserve">
+        <value>Message types</value>
+    </data>
+    <data name="PacketViewerViewModel_SeparatorDialog_Tab" xml:space="preserve">
+        <value>Horizontal tabulation [ Tab ]</value>
+    </data>
+    <data name="Separator_Title" xml:space="preserve">
+        <value>Save packet</value>
+    </data>
+    <data name="Separator_Path" xml:space="preserve">
+        <value>Enter the path</value>
+    </data>
+    <data name="PacketViewer_Open" xml:space="preserve">
+        <value>Open packet viewer</value>
+    </data>
 </root>

--- a/src/Asv.Avalonia.Example/RS.ru.resx
+++ b/src/Asv.Avalonia.Example/RS.ru.resx
@@ -71,4 +71,52 @@
     <data name="ParamPageViewModel_DataLossDialog_CloseButtonText" xml:space="preserve">
         <value>Отмена</value>
     </data>
+    <data name="PacketViewerViewModel_SeparatorDialog_Title" xml:space="preserve">
+        <value>Выберите разделитель</value>
+    </data>
+    <data name="PacketViewerViewModel_SeparatorDialog_DialogPrimaryButton" xml:space="preserve">
+        <value>Выбрать</value>
+    </data>
+    <data name="PacketViewerViewModel_SeparatorDialog_DialogSecondaryButton" xml:space="preserve">
+        <value>Отмена</value>
+    </data>
+    <data name="PacketViewerViewModel_SeparatorDialog_Coma" xml:space="preserve">
+        <value>Запятая [ , ]</value>
+    </data>
+    <data name="PacketViewerViewModel_SeparatorDialog_Semicolon" xml:space="preserve">
+        <value>Точка с запятой [ ; ]</value>
+    </data>
+    <data name="PacketViewerView_CheckAll" xml:space="preserve">
+        <value>Выбрать/Снять все</value>
+    </data>
+    <data name="PacketViewerView_PlayPause" xml:space="preserve">
+        <value>Воспроизвести/Пауза</value>
+    </data>
+    <data name="PacketViewerView_ClearAll" xml:space="preserve">
+        <value>Очистить все пакеты</value>
+    </data>
+    <data name="PacketViewerView_Save" xml:space="preserve">
+        <value>Сохранить как CSV</value>
+    </data>
+    <data name="PacketViewerViewDockPanelText" xml:space="preserve">
+        <value>Просмотр пакетов</value>
+    </data>
+    <data name="PacketViewer_Expander_MessageSources" xml:space="preserve">
+        <value>Источники сообщений</value>
+    </data>
+    <data name="PacketViewer_Expander_MessageTypes" xml:space="preserve">
+        <value>Типы сообщений</value>
+    </data>
+    <data name="PacketViewerViewModel_SeparatorDialog_Tab" xml:space="preserve">
+        <value>Горизонтальная табуляция [Tab]</value>
+    </data>
+    <data name="Separator_Title" xml:space="preserve">
+        <value>Сохранение пакетов</value>
+    </data>
+    <data name="Separator_Path" xml:space="preserve">
+        <value>Введите путь</value>
+    </data>
+    <data name="PacketViewer_Open" xml:space="preserve">
+        <value>Открыть просмотр пакетов</value>
+    </data>
 </root>

--- a/src/Asv.Avalonia.IO/Pages/Settings/Connections/PortViewModel.cs
+++ b/src/Asv.Avalonia.IO/Pages/Settings/Connections/PortViewModel.cs
@@ -32,13 +32,17 @@ public class PortViewModel : RoutableViewModel, IPortViewModel
         TagsView = TagsSource.ToNotifyCollectionChangedSlim().DisposeItWith(Disposable);
         _hasValidationError = new BindableReactiveProperty<bool>().DisposeItWith(Disposable);
         _hasChanges = new BindableReactiveProperty<bool>().DisposeItWith(Disposable);
-        SaveChangesCommand = new ReactiveCommand(x=>Task.Factory.StartNew(SaveChanges,null, TaskCreationOptions.LongRunning)).DisposeItWith(Disposable);
+        SaveChangesCommand = new ReactiveCommand(x =>
+            Task.Factory.StartNew(SaveChanges, null, TaskCreationOptions.LongRunning)
+        ).DisposeItWith(Disposable);
         _hasValidationError
             .Subscribe(x => SaveChangesCommand.ChangeCanExecute(!x))
             .DisposeItWith(Disposable);
         CancelChangesCommand = new ReactiveCommand(CancelChanges).DisposeItWith(Disposable);
         IsEnabled = new BindableReactiveProperty<bool>().DisposeItWith(Disposable);
-        IsEnabled.SubscribeAwait(ChangeEnabled, AwaitOperation.Drop, false).DisposeItWith(Disposable);
+        IsEnabled
+            .SubscribeAwait(ChangeEnabled, AwaitOperation.Drop, false)
+            .DisposeItWith(Disposable);
         AddToValidation(Name = new BindableReactiveProperty<string>(), ValidateName);
 
         RemovePortCommand = new ReactiveCommand(RemovePort).DisposeItWith(Disposable);

--- a/src/Asv.Avalonia.IO/Pages/Settings/Connections/SettingsConnectionViewModel.cs
+++ b/src/Asv.Avalonia.IO/Pages/Settings/Connections/SettingsConnectionViewModel.cs
@@ -55,7 +55,7 @@ public class SettingsConnectionViewModel
             source.Add(port);
         }
 
-        deviceManager.Router.PortAdded.Subscribe(x =>source.Add(x) ).DisposeItWith(Disposable);
+        deviceManager.Router.PortAdded.Subscribe(x => source.Add(x)).DisposeItWith(Disposable);
         deviceManager.Router.PortRemoved.Subscribe(x => source.Remove(x)).DisposeItWith(Disposable);
     }
 

--- a/src/Asv.Avalonia.IO/Services/DeviceManager.cs
+++ b/src/Asv.Avalonia.IO/Services/DeviceManager.cs
@@ -136,7 +136,8 @@ public class DeviceManager : IDeviceManager, IDisposable, IAsyncDisposable
 
     public async ValueTask DisposeAsync()
     {
-        if (_sub1 != null) await CastAndDispose(_sub1);
+        if (_sub1 != null)
+            await CastAndDispose(_sub1);
         await Router.DisposeAsync();
         await Explorer.DisposeAsync();
 


### PR DESCRIPTION
Implement packet viewer functionality in Asv.Avalonia.Example with all original features including:
- Real-time packet display
- Source and type filtering
- Rate calculation
- CSV export capability
- Highlighting selected packet types

The viewer maintains the same UI/UX as in Asv.Drones but uses Avalonia framework components. All strings are properly localized through resource files.
Asana: https://app.asana.com/0/1203851531040615/1209400123003043/f