### PR TITLE
fix: sync internal workspace panels with Children on remove

### DIFF
--- a/src/Asv.Avalonia/Core/Controls/Workspace/WorkspacePanel.cs
+++ b/src/Asv.Avalonia/Core/Controls/Workspace/WorkspacePanel.cs
@@ -223,6 +223,12 @@ public partial class WorkspacePanel : Panel
 
     private void RefreshChildren()
     {
+        var current = Children.ToHashSet();
+        RemoveStale(_leftPanel.Children, current);
+        RemoveStale(_rightPanel.Children, current);
+        RemoveStale(_centerPanel.Children, current);
+        RemoveStale(_bottomPanel, current);
+
         foreach (var control in Children)
         {
             var dock = GetDock(control);
@@ -325,6 +331,17 @@ public partial class WorkspacePanel : Panel
             else
             {
                 _centerPanel.Children[i].ClearValue(DockPanel.DockProperty);
+            }
+        }
+    }
+
+    private static void RemoveStale(IList<Control> panel, HashSet<Control> current)
+    {
+        for (var i = panel.Count - 1; i >= 0; i--)
+        {
+            if (!current.Contains(panel[i]))
+            {
+                panel.RemoveAt(i);
             }
         }
     }

--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -3,7 +3,7 @@
         <Nullable>enable</Nullable>
         <ApiVersion>1.0.0</ApiVersion>
         <TargetFramework>net10.0</TargetFramework>
-        <ProductVersion>2.4.3</ProductVersion>
+        <ProductVersion>2.5.0-dev.0</ProductVersion>
         <AvaloniaVersion>11.3.12</AvaloniaVersion>
         <DotNetVersion>10.0.0</DotNetVersion>
         <R3Version>1.3.0</R3Version>


### PR DESCRIPTION
## Проблема
WorkspacePanel имеет логику расскидывания  Children во внутренние панели. RefreshChildren проверяет «если контрол ещё не в нужной панели - добавь». Но обратной логики нет: «если контрол уже нет в Children, то убери из внутренней панели».  Внутренние панели (_leftPanel.Children и т.д.) — это отдельные коллекции, не привязанные к ItemsControl. Avalonia не знает о них и не чистит их автоматически.
Пока элементы только добавлялись и не удалялись в коротком временном интервале  было не заметно. Как только начался активный цикл add/remove (или Reset от Sort) - призрачные контролы скапливались во внутренних панелях и увеличивали отступы .

## Решение

В RefreshChildren синхронизировать внутренние панели с Children: убирать из внутренних панелей элементы, которых уже нет в Children.

## Демонстрация 

### До
По факту имеем 5 устройств во FlightMode, периодически подключающихся и отключающихся, а visual tree показывает на все ранее добавленные элементы 
<img width="2554" height="1390" alt="res-2026-03-12_18-26" src="https://github.com/user-attachments/assets/9a5153d2-8dd3-4d07-aa29-1c032e1b08bf" />

### После

Количество виузальных элементов соотвествует количеству подключенных устройств

<img width="2559" height="1392" alt="2026-04-15_17-30" src="https://github.com/user-attachments/assets/6001478f-648d-4170-b8bf-314bb5971996" />


Asana:
https://app.asana.com/1/1200746044236722/project/1211373667593556/task/1214072743435702?focus=true