### PR TITLE
fix: device-init via observable instead of ctor-time virtual

### DIFF
--- a/src/Asv.Avalonia.IO/Shell/Pages/Device/DevicePageCore.cs
+++ b/src/Asv.Avalonia.IO/Shell/Pages/Device/DevicePageCore.cs
@@ -1,4 +1,3 @@
-using System.Collections.Specialized;
 using System.Diagnostics;
 using Asv.Common;
 using Asv.IO;
@@ -56,11 +55,12 @@ public sealed class DevicePageCore : IDisposable
         OnDeviceDisconnecting = _onDeviceDisconnecting.AsObservable();
     }
 
-    public event Action<IClientDevice, CancellationToken>? OnDeviceInitialized;
     public ReadOnlyReactiveProperty<DeviceWrapper?> Target => _target;
+    public ReadOnlyReactiveProperty<bool> IsDeviceInitialized => _isDeviceInitialized;
+    public Observable<DeviceWrapper> OnDeviceInitialized =>
+        _target.Where(x => x.HasValue).Select(x => x!.Value);
     public Observable<Unit> OnDeviceDisconnecting { get; }
     public Observable<Unit> OnDeviceDisconnected { get; }
-    public ReadOnlyReactiveProperty<bool> IsDeviceInitialized => _isDeviceInitialized;
 
     public void Init(NavArgs args)
     {
@@ -82,7 +82,10 @@ public sealed class DevicePageCore : IDisposable
 
         _isDeviceInitialized
             .Where(isInit => isInit)
-            .Subscribe(_ => _owner.Layout.LoadAllAsync(CancellationToken.None).SafeFireAndForget())
+            .SubscribeAwait(
+                async (_, ct) => await _owner.Layout.LoadAllAsync(ct),
+                AwaitOperation.Switch
+            )
             .DisposeItWith(_disposable);
         _onDeviceDisconnected
             .Synchronize()
@@ -121,6 +124,7 @@ public sealed class DevicePageCore : IDisposable
         _deviceDisconnectedToken?.Dispose();
         _deviceDisconnectedToken = null;
         _waitInitSubscription.Disposable?.Dispose();
+        _target.OnNext(null);
     }
 
     private void DeviceFoundButNotInitialized(IClientDevice device)
@@ -140,7 +144,6 @@ public sealed class DevicePageCore : IDisposable
         {
             _waitInitSubscription.Disposable?.Dispose();
             _deviceDisconnectedToken = new CancellationTokenSource();
-            OnDeviceInitialized?.Invoke(device, _deviceDisconnectedToken.Token);
             _target.OnNext(new DeviceWrapper(device, _deviceDisconnectedToken.Token));
             _isDeviceInitialized.Value = true;
         }

--- a/src/Asv.Avalonia.IO/Shell/Pages/Device/DevicePageViewModel.cs
+++ b/src/Asv.Avalonia.IO/Shell/Pages/Device/DevicePageViewModel.cs
@@ -1,7 +1,4 @@
-﻿using System.Collections.Specialized;
-using Asv.Common;
-using Asv.IO;
-using Asv.Modeling;
+﻿using Asv.Common;
 using Microsoft.Extensions.Logging;
 using R3;
 
@@ -22,40 +19,28 @@ public abstract class DevicePageViewModel<T> : PageViewModel<T>, IDevicePage
     )
         : base(id, context, loggerFactory, dialogService, ext)
     {
+        ArgumentNullException.ThrowIfNull(context);
         ArgumentNullException.ThrowIfNull(devices);
         ArgumentNullException.ThrowIfNull(loggerFactory);
+        ArgumentNullException.ThrowIfNull(dialogService);
+        ArgumentNullException.ThrowIfNull(ext);
+
         _deviceCore = new DevicePageCore(
             devices,
             loggerFactory.CreateLogger<DevicePageCore>(),
             this
-        );
+        ).DisposeItWith(Disposable);
         _deviceCore.Init(context.NavArgs);
-        _deviceCore.OnDeviceInitialized -= AfterDeviceInitialized;
-        _deviceCore.OnDeviceInitialized += AfterDeviceInitialized;
 
         IsDeviceInitialized = _deviceCore
-            .IsDeviceInitialized.ToReadOnlyBindableReactiveProperty()
+            .IsDeviceInitialized.ObserveOnUIThreadDispatcher()
+            .ToReadOnlyBindableReactiveProperty()
             .DisposeItWith(Disposable);
-    }
-
-    protected abstract void AfterDeviceInitialized(
-        IClientDevice device,
-        CancellationToken onDisconnectedToken
-    );
-
-    protected override void Dispose(bool disposing)
-    {
-        if (disposing)
-        {
-            _deviceCore.OnDeviceInitialized -= AfterDeviceInitialized;
-            _deviceCore.Dispose();
-        }
-
-        base.Dispose(disposing);
     }
 
     public ReadOnlyReactiveProperty<DeviceWrapper?> Target => _deviceCore.Target;
     public IReadOnlyBindableReactiveProperty<bool> IsDeviceInitialized { get; }
+    public Observable<DeviceWrapper> OnDeviceInitialized => _deviceCore.OnDeviceInitialized;
     public Observable<Unit> OnDeviceDisconnecting => _deviceCore.OnDeviceDisconnecting;
     public Observable<Unit> OnDeviceDisconnected => _deviceCore.OnDeviceDisconnected;
 }

--- a/src/Asv.Avalonia.IO/Shell/Pages/Device/Tree/TreeDevicePageViewModel.cs
+++ b/src/Asv.Avalonia.IO/Shell/Pages/Device/Tree/TreeDevicePageViewModel.cs
@@ -1,5 +1,4 @@
 using Asv.Common;
-using Asv.IO;
 using Asv.Modeling;
 using Microsoft.Extensions.Logging;
 using R3;
@@ -29,52 +28,31 @@ public abstract class TreeDevicePageViewModel<TContext, TSubPage>
             devices,
             loggerFactory.CreateLogger<DevicePageCore>(),
             this
-        );
+        ).DisposeItWith(Disposable);
         _deviceCore.Init(context.NavArgs);
-        _deviceCore.OnDeviceInitialized -= AfterDeviceInitialized;
-        _deviceCore.OnDeviceInitialized -= AfterDeviceInitializedBase;
-        _deviceCore.OnDeviceInitialized += AfterDeviceInitializedBase;
-        _deviceCore.OnDeviceInitialized += AfterDeviceInitialized;
+
+        _deviceCore
+            .OnDeviceInitialized.ObserveOnUIThreadDispatcher()
+            .Subscribe(w =>
+                w.WhenDisconnectedToken.Register(() =>
+                {
+                    Nodes.RemoveAll();
+                    SelectedPage.Value?.Dispose();
+                    SelectedNode.Value?.Dispose();
+                    SelectedPage.Value = null;
+                    SelectedNode.Value = null;
+                })
+            )
+            .DisposeItWith(Disposable);
 
         IsDeviceInitialized = _deviceCore
             .IsDeviceInitialized.ToReadOnlyBindableReactiveProperty()
             .DisposeItWith(Disposable);
     }
 
-    private void AfterDeviceInitializedBase(
-        IClientDevice device,
-        CancellationToken onDisconnectedToken
-    )
-    {
-        onDisconnectedToken.Register(() =>
-        {
-            Nodes.RemoveAll();
-            SelectedPage.Value?.Dispose();
-            SelectedNode.Value?.Dispose();
-            SelectedPage.Value = null;
-            SelectedNode.Value = null;
-        });
-    }
-
-    protected abstract void AfterDeviceInitialized(
-        IClientDevice device,
-        CancellationToken onDisconnectedToken
-    );
-
-    protected override void Dispose(bool disposing)
-    {
-        if (disposing)
-        {
-            _deviceCore.OnDeviceInitialized -= AfterDeviceInitialized;
-            _deviceCore.OnDeviceInitialized -= AfterDeviceInitializedBase;
-            _deviceCore.Dispose();
-        }
-
-        base.Dispose(disposing);
-    }
-
     public ReadOnlyReactiveProperty<DeviceWrapper?> Target => _deviceCore.Target;
     public IReadOnlyBindableReactiveProperty<bool> IsDeviceInitialized { get; }
+    public Observable<DeviceWrapper> OnDeviceInitialized => _deviceCore.OnDeviceInitialized;
     public Observable<Unit> OnDeviceDisconnecting => _deviceCore.OnDeviceDisconnecting;
     public Observable<Unit> OnDeviceDisconnected => _deviceCore.OnDeviceDisconnected;
 }

--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -1,7 +1,7 @@
 <Project>
     <PropertyGroup>
         <ApiVersion>3.0.0</ApiVersion>
-        <ProductVersion>3.0.0-dev.16</ProductVersion>
+        <ProductVersion>3.0.0-dev.17</ProductVersion>
         <LauncherVersion>0.0.1-dev.0</LauncherVersion>
         <TargetFramework>net10.0</TargetFramework>
 


### PR DESCRIPTION
AfterDeviceInitialized fired from the base ctor before derived fields were set (NRE on already-connected device). Replaced with an OnDeviceInitialized observable that pages subscribe to — UI-thread delivery, safe and correct on reconnects.

---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1215273213134188