### PR TITLE
fix: prevent shell root duplication in GoTo

### DIFF
--- a/src/Asv.Avalonia/Shell/ShellMixin.cs
+++ b/src/Asv.Avalonia/Shell/ShellMixin.cs
@@ -1,6 +1,4 @@
-﻿using System.Diagnostics;
-using Asv.Modeling;
-using Avalonia.Controls;
+﻿using Asv.Modeling;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
 
@@ -12,14 +10,26 @@ public static class ShellMixin
     {
         public ValueTask GoTo(NavPath path)
         {
-            var path1 = new List<NavId> { new(ShellViewModel.TypeId) };
-            path1.AddRange(path);
-            if (sender is IShell shell)
+            var rootId = new NavId(ShellViewModel.TypeId);
+
+            NavPath fullPath;
+            if (path.Count > 0 && path[0] == rootId)
             {
-                return GoToShell(shell, new NavPath(path1));
+                fullPath = path;
+            }
+            else
+            {
+                var items = new List<NavId> { rootId };
+                items.AddRange(path);
+                fullPath = new NavPath(items);
             }
 
-            return sender.Events.Rise(new NavigateEvent<IViewModel>(sender, new NavPath(path1)));
+            if (sender is IShell shell)
+            {
+                return GoToShell(shell, fullPath);
+            }
+
+            return sender.Events.Rise(new NavigateEvent<IViewModel>(sender, fullPath));
         }
     }
 

--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -1,7 +1,7 @@
 <Project>
     <PropertyGroup>
         <ApiVersion>3.0.0</ApiVersion>
-        <ProductVersion>3.0.0-dev.19</ProductVersion>
+        <ProductVersion>3.0.0-dev.20</ProductVersion>
         <LauncherVersion>0.0.1-dev.0</LauncherVersion>
         <TargetFramework>net10.0</TargetFramework>
 


### PR DESCRIPTION
GoTo always prepended the shell root, so rooted paths (GetPathFromRoot) became "shell/shell/..." and threw on navigation, breaking dialog close. Now the root is added only if missing.