### PR TITLE
fix: create home items from ui thread

### DIFF
--- a/src/Asv.Avalonia.IO/Shell/Pages/Home/HomePageDeviceListExtension.cs
+++ b/src/Asv.Avalonia.IO/Shell/Pages/Home/HomePageDeviceListExtension.cs
@@ -1,6 +1,7 @@
 using Asv.Common;
 using Asv.IO;
 using Asv.Modeling;
+using Avalonia.Threading;
 using Microsoft.Extensions.Logging;
 using R3;
 
@@ -28,7 +29,17 @@ public class HomePageDeviceListExtension : IExtensionFor<IHomePage>
 
     public void Extend(IHomePage context, CompositeDisposable contextDispose)
     {
-        _svc.Explorer.InitializedDevices.PopulateTo(context.Items, TryAdd, Remove)
+        var synchronizationContext = new AvaloniaSynchronizationContext(
+            Dispatcher.UIThread,
+            DispatcherPriority.Default
+        );
+
+        _svc.Explorer.InitializedDevices.PopulateTo(
+                context.Items,
+                TryAdd,
+                Remove,
+                synchronizationContext: synchronizationContext
+            )
             .DisposeItWith(contextDispose);
     }
 

--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -1,7 +1,7 @@
 <Project>
     <PropertyGroup>
         <ApiVersion>3.0.0</ApiVersion>
-        <ProductVersion>3.0.0-dev.30</ProductVersion>
+        <ProductVersion>3.0.0-dev.31</ProductVersion>
         <LauncherVersion>0.0.1-dev.1</LauncherVersion>
         <TargetFramework>net10.0</TargetFramework>
 


### PR DESCRIPTION
Fix race where HomePageDeviceItem.Device could be null in HomePageDeviceItemAction.Extend. The item was built on a background thread while extensions run on the UI thread, so Device (assigned after the base ctor) wasn't always set when Extend read it. Now items are constructed on the UI thread.