### PR TITLE
feat: add WithDefaultTarget method to LauncherCommandLineParser

### DIFF
--- a/src/Asv.Avalonia.Example.Launcher/Program.cs
+++ b/src/Asv.Avalonia.Example.Launcher/Program.cs
@@ -1,4 +1,5 @@
 using Asv.Avalonia.Launcher.Contracts;
+using Asv.Avalonia.Launcher.Orchestration;
 using Avalonia;
 using Avalonia.Controls;
 
@@ -6,13 +7,18 @@ namespace Asv.Avalonia.Example.Launcher;
 
 internal static class Program
 {
+    private const string DefaultTargetExecutableName = "Asv.Avalonia.Example.Desktop.exe";
+
     [STAThread]
     public static void Main(string[] args)
     {
         try
         {
             BuildAvaloniaApp()
-                .StartWithClassicDesktopLifetime(args, ShutdownMode.OnMainWindowClose);
+                .StartWithClassicDesktopLifetime(
+                    LauncherCommandLineParser.WithDefaultTarget(args, DefaultTargetExecutableName),
+                    ShutdownMode.OnMainWindowClose
+                );
         }
         catch (Exception ex)
         {

--- a/src/Asv.Avalonia.Launcher/Orchestration/Parts/LauncherCommandLineParser.cs
+++ b/src/Asv.Avalonia.Launcher/Orchestration/Parts/LauncherCommandLineParser.cs
@@ -11,10 +11,64 @@ public static class LauncherCommandLineParser
         out string errorMessage
     )
     {
+        return TryParseCore(args, null, out options, out errorMessage, out _, out _);
+    }
+
+    /// <summary>
+    /// Adds a default target executable when the launcher arguments are otherwise valid and do not
+    /// specify one. Relative target paths are resolved against
+    /// <see cref="AppContext.BaseDirectory"/>.
+    /// </summary>
+    /// <param name="args">The launcher command-line arguments.</param>
+    /// <param name="defaultTargetPath">The default target executable path.</param>
+    /// <returns>
+    /// The original arguments when they specify a target or are invalid; otherwise, a new argument
+    /// array containing the default target.
+    /// </returns>
+    public static string[] WithDefaultTarget(string[] args, string defaultTargetPath)
+    {
+        ArgumentNullException.ThrowIfNull(args);
+        ArgumentException.ThrowIfNullOrWhiteSpace(defaultTargetPath);
+
+        var resolvedTargetPath = Path.GetFullPath(defaultTargetPath, AppContext.BaseDirectory);
+        if (
+            !TryParseCore(
+                args,
+                resolvedTargetPath,
+                out _,
+                out _,
+                out var insertionIndex,
+                out var usedDefaultTarget
+            ) || !usedDefaultTarget
+        )
+        {
+            return args;
+        }
+
+        var result = new string[args.Length + 2];
+        Array.Copy(args, 0, result, 0, insertionIndex);
+        result[insertionIndex] = LauncherCommandLineArguments.TargetArg;
+        result[insertionIndex + 1] = resolvedTargetPath;
+        Array.Copy(args, insertionIndex, result, insertionIndex + 2, args.Length - insertionIndex);
+
+        return result;
+    }
+
+    private static bool TryParseCore(
+        IReadOnlyList<string> args,
+        string? defaultTargetPath,
+        out LauncherStartOptions? options,
+        out string errorMessage,
+        out int targetInsertionIndex,
+        out bool usedDefaultTarget
+    )
+    {
         options = null;
         errorMessage = string.Empty;
+        targetInsertionIndex = args.Count;
+        usedDefaultTarget = false;
 
-        if (args.Count == 0)
+        if (args.Count == 0 && string.IsNullOrWhiteSpace(defaultTargetPath))
         {
             errorMessage = "Missing launcher arguments.";
             return false;
@@ -26,6 +80,7 @@ public static class LauncherCommandLineParser
         var sessionToken = Guid.NewGuid().ToString("N");
         var startupTimeout = TimeSpan.FromSeconds(10);
         var passthroughMode = false;
+        var targetArgumentSpecified = false;
 
         for (var i = 0; i < args.Count; i++)
         {
@@ -41,8 +96,10 @@ public static class LauncherCommandLineParser
             {
                 case LauncherCommandLineArguments.PassthroughArgsSeparator:
                     passthroughMode = true;
+                    targetInsertionIndex = i;
                     break;
                 case LauncherCommandLineArguments.TargetArg:
+                    targetArgumentSpecified = true;
                     if (!TryReadValue(args, ref i, out targetPath, out errorMessage))
                     {
                         return false;
@@ -79,6 +136,16 @@ public static class LauncherCommandLineParser
                     errorMessage = $"Unknown launcher argument: '{current}'.";
                     return false;
             }
+        }
+
+        if (
+            !targetArgumentSpecified
+            && string.IsNullOrWhiteSpace(targetPath)
+            && !string.IsNullOrWhiteSpace(defaultTargetPath)
+        )
+        {
+            targetPath = defaultTargetPath;
+            usedDefaultTarget = true;
         }
 
         if (string.IsNullOrWhiteSpace(targetPath))

--- a/src/Asv.Avalonia.Test/Asv.Avalonia.Test.csproj
+++ b/src/Asv.Avalonia.Test/Asv.Avalonia.Test.csproj
@@ -14,6 +14,7 @@
     </ItemGroup>
 
     <ItemGroup>
+      <ProjectReference Include="..\Asv.Avalonia.Launcher\Asv.Avalonia.Launcher.csproj" />
       <ProjectReference Include="..\Asv.Avalonia\Asv.Avalonia.csproj" />
       <ProjectReference Include="..\Asv.Avalonia.Example\Asv.Avalonia.Example.csproj" />
       <ProjectReference Include="..\Asv.Avalonia.GeoMap\Asv.Avalonia.GeoMap.csproj" />

--- a/src/Asv.Avalonia.Test/Asv.Avalonia.Test.csproj.DotSettings
+++ b/src/Asv.Avalonia.Test/Asv.Avalonia.Test.csproj.DotSettings
@@ -10,4 +10,5 @@
 	<s:Boolean x:Key="/Default/CodeInspection/NamespaceProvider/NamespaceFoldersToSkip/=services_005Cunits_005Cdatasize/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/CodeInspection/NamespaceProvider/NamespaceFoldersToSkip/=services_005Cunits_005Cformatters/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/CodeInspection/NamespaceProvider/NamespaceFoldersToSkip/=viewmodel/@EntryIndexedValue">True</s:Boolean>
-	<s:Boolean x:Key="/Default/CodeInspection/NamespaceProvider/NamespaceFoldersToSkip/=viewmodel_005Croutable/@EntryIndexedValue">True</s:Boolean></wpf:ResourceDictionary>
+	<s:Boolean x:Key="/Default/CodeInspection/NamespaceProvider/NamespaceFoldersToSkip/=viewmodel_005Croutable/@EntryIndexedValue">True</s:Boolean>
+	<s:Boolean x:Key="/Default/CodeInspection/NamespaceProvider/NamespaceFoldersToSkip/=_005Fmove_005Fto_005Fasv_002Davalonia_002Dlauncher_002Dtest/@EntryIndexedValue">True</s:Boolean></wpf:ResourceDictionary>

--- a/src/Asv.Avalonia.Test/_move_to_asv-avalonia-launcher-test/LauncherCommandLineParserTest.cs
+++ b/src/Asv.Avalonia.Test/_move_to_asv-avalonia-launcher-test/LauncherCommandLineParserTest.cs
@@ -1,0 +1,127 @@
+using Asv.Avalonia.Launcher.Api;
+using Asv.Avalonia.Launcher.Orchestration;
+using Xunit;
+
+namespace Asv.Avalonia.Test;
+
+public class LauncherCommandLineParserTest
+{
+    [Fact]
+    public void WithDefaultTarget_TargetSpecified_ReturnsOriginalArguments()
+    {
+        // Arrange
+        var args = new[] { LauncherCommandLineArguments.TargetArg, "custom.exe" };
+
+        // Act
+        var result = LauncherCommandLineParser.WithDefaultTarget(args, "default.exe");
+
+        // Assert
+        Assert.Same(args, result);
+    }
+
+    [Fact]
+    public void WithDefaultTarget_TargetMissing_AddsResolvedDefaultTarget()
+    {
+        // Arrange
+        var args = new[] { LauncherCommandLineArguments.TimeoutSecArg, "30" };
+        var expectedPath = Path.GetFullPath("default.exe", AppContext.BaseDirectory);
+
+        // Act
+        var result = LauncherCommandLineParser.WithDefaultTarget(args, "default.exe");
+
+        // Assert
+        Assert.Equal(
+            [
+                LauncherCommandLineArguments.TimeoutSecArg,
+                "30",
+                LauncherCommandLineArguments.TargetArg,
+                expectedPath,
+            ],
+            result
+        );
+    }
+
+    [Fact]
+    public void WithDefaultTarget_PassthroughArguments_InsertsTargetBeforeSeparator()
+    {
+        // Arrange
+        var args = new[]
+        {
+            LauncherCommandLineArguments.PassthroughArgsSeparator,
+            "--target-app-argument",
+        };
+        var expectedPath = Path.GetFullPath("default.exe", AppContext.BaseDirectory);
+
+        // Act
+        var result = LauncherCommandLineParser.WithDefaultTarget(args, "default.exe");
+
+        // Assert
+        Assert.Equal(
+            [
+                LauncherCommandLineArguments.TargetArg,
+                expectedPath,
+                LauncherCommandLineArguments.PassthroughArgsSeparator,
+                "--target-app-argument",
+            ],
+            result
+        );
+    }
+
+    [Fact]
+    public void WithDefaultTarget_TargetTokenUsedAsOptionValue_AddsDefaultTarget()
+    {
+        // Arrange
+        var args = new[]
+        {
+            LauncherCommandLineArguments.PipeArg,
+            LauncherCommandLineArguments.TargetArg,
+        };
+        var expectedPath = Path.GetFullPath("default.exe", AppContext.BaseDirectory);
+
+        // Act
+        var result = LauncherCommandLineParser.WithDefaultTarget(args, "default.exe");
+
+        // Assert
+        Assert.Equal(
+            [
+                LauncherCommandLineArguments.PipeArg,
+                LauncherCommandLineArguments.TargetArg,
+                LauncherCommandLineArguments.TargetArg,
+                expectedPath,
+            ],
+            result
+        );
+    }
+
+    [Fact]
+    public void WithDefaultTarget_SeparatorTokenUsedAsOptionValue_PreservesExplicitTarget()
+    {
+        // Arrange
+        var args = new[]
+        {
+            LauncherCommandLineArguments.PipeArg,
+            LauncherCommandLineArguments.PassthroughArgsSeparator,
+            LauncherCommandLineArguments.TargetArg,
+            "custom.exe",
+        };
+
+        // Act
+        var result = LauncherCommandLineParser.WithDefaultTarget(args, "default.exe");
+
+        // Assert
+        Assert.Same(args, result);
+    }
+
+    [Fact]
+    public void WithDefaultTarget_InvalidArguments_ReturnsOriginalArguments()
+    {
+        // Arrange
+        var args = new[] { LauncherCommandLineArguments.TimeoutSecArg, "invalid" };
+
+        // Act
+        var result = LauncherCommandLineParser.WithDefaultTarget(args, "default.exe");
+
+        // Assert
+        Assert.Same(args, result);
+    }
+}

--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -2,7 +2,7 @@
     <PropertyGroup>
         <ApiVersion>3.0.0</ApiVersion>
         <ProductVersion>3.0.0-dev.87</ProductVersion>
-        <LauncherVersion>0.0.1-dev.2</LauncherVersion>
+        <LauncherVersion>0.0.1-dev.3</LauncherVersion>
         <TargetFramework>net10.0</TargetFramework>
 
         <AvaloniaVersion>12.0.4</AvaloniaVersion>


### PR DESCRIPTION
add tests for LauncherCommandLineParser.cs
add WithDefaultTarget support in Asv.Avalonia.Example.Launcher 
update launcher version to 0.0.1-dev.3

Asana: https://app.asana.com/1/1200746044236722/project/1203851531040615/task/1216940068169169?focus=true