### PR TITLE
fix: use concrete enum type in HistoricalEnumProperty undo/redo

### DIFF
--- a/src/Asv.Avalonia.Example/Shell/Pages/ControlsGallery/DialogControls/DialogControlsPageViewModel.cs
+++ b/src/Asv.Avalonia.Example/Shell/Pages/ControlsGallery/DialogControls/DialogControlsPageViewModel.cs
@@ -54,9 +54,9 @@ public class DialogControlsPageViewModel : ControlsGallerySubPage
     private readonly ReactiveProperty<string?> _customDialogSecondaryButtonText;
     private readonly ReactiveProperty<bool> _customDialogIsSecondaryButtonEnabled;
 
-    private readonly ReactiveProperty<Enum> _customDialogResult;
-    private readonly ReactiveProperty<Enum> _yesOrNoDialogResult;
-    private readonly ReactiveProperty<Enum> _saveCancelDialogResult;
+    private readonly ReactiveProperty<ContentDialogResult> _customDialogResult;
+    private readonly ReactiveProperty<ConfirmationStatus> _yesOrNoDialogResult;
+    private readonly ReactiveProperty<ConfirmationStatus> _saveCancelDialogResult;
     private readonly ReactiveProperty<string?> _showInputDialogResult;
     private readonly ReactiveProperty<string?> _showHotKeyCaptureDialogResult;
     private readonly ReactiveProperty<GeoPoint> _geoPointDialogResult;
@@ -220,13 +220,13 @@ public class DialogControlsPageViewModel : ControlsGallerySubPage
 
         #region Dialog results
 
-        _customDialogResult = new ReactiveProperty<Enum>(ContentDialogResult.None).DisposeItWith(
-            Disposable
-        );
-        _yesOrNoDialogResult = new ReactiveProperty<Enum>(
+        _customDialogResult = new ReactiveProperty<ContentDialogResult>(
+            ContentDialogResult.None
+        ).DisposeItWith(Disposable);
+        _yesOrNoDialogResult = new ReactiveProperty<ConfirmationStatus>(
             ConfirmationStatus.Undefined
         ).DisposeItWith(Disposable);
-        _saveCancelDialogResult = new ReactiveProperty<Enum>(
+        _saveCancelDialogResult = new ReactiveProperty<ConfirmationStatus>(
             ConfirmationStatus.Undefined
         ).DisposeItWith(Disposable);
         _showInputDialogResult = new ReactiveProperty<string?>().DisposeItWith(Disposable);

--- a/src/Asv.Avalonia.Example/Shell/Pages/ControlsGallery/HistoricalControls/HistoricalControlsPageViewModel.cs
+++ b/src/Asv.Avalonia.Example/Shell/Pages/ControlsGallery/HistoricalControls/HistoricalControlsPageViewModel.cs
@@ -35,8 +35,8 @@ public class HistoricalControlsPageViewModel : ControlsGallerySubPage
     private readonly ReactiveProperty<string?> _stringWithOneValidation;
     private readonly ReactiveProperty<string?> _stringWithoutValidation;
     private readonly ReactiveProperty<GeoPoint> _geoPointProperty;
-    private readonly ReactiveProperty<Enum> _tagTypeProp;
-    private readonly ReactiveProperty<Enum> _rttBoxStatusProp;
+    private readonly ReactiveProperty<AsvColorKind> _tagTypeProp;
+    private readonly ReactiveProperty<AsvColorKind> _rttBoxStatusProp;
     private readonly Subject<Unit> _layoutChanged = new();
 
     public HistoricalControlsPageViewModel()
@@ -67,8 +67,10 @@ public class HistoricalControlsPageViewModel : ControlsGallerySubPage
         _stringWithOneValidation = new ReactiveProperty<string?>().DisposeItWith(Disposable);
         _stringWithManyValidations = new ReactiveProperty<string?>().DisposeItWith(Disposable);
         _geoPointProperty = new ReactiveProperty<GeoPoint>().DisposeItWith(Disposable);
-        _tagTypeProp = new ReactiveProperty<Enum>(AsvColorKind.Error).DisposeItWith(Disposable);
-        _rttBoxStatusProp = new ReactiveProperty<Enum>(AsvColorKind.Success).DisposeItWith(
+        _tagTypeProp = new ReactiveProperty<AsvColorKind>(AsvColorKind.Error).DisposeItWith(
+            Disposable
+        );
+        _rttBoxStatusProp = new ReactiveProperty<AsvColorKind>(AsvColorKind.Success).DisposeItWith(
             Disposable
         );
 

--- a/src/Asv.Avalonia.Example/Shell/Pages/ControlsGallery/InfoBoxControls/InfoBoxControlsPageViewModel.cs
+++ b/src/Asv.Avalonia.Example/Shell/Pages/ControlsGallery/InfoBoxControls/InfoBoxControlsPageViewModel.cs
@@ -13,7 +13,7 @@ public class InfoBoxControlsPageViewModel : ControlsGallerySubPage
     public const string PageId = "info-box-controls";
     public const MaterialIconKind PageIcon = MaterialIconKind.InfoBox;
 
-    private readonly ReactiveProperty<Enum> _severity;
+    private readonly ReactiveProperty<InfoBarSeverity> _severity;
     private readonly ReactiveProperty<string?> _infoBoxMessage;
     private readonly ReactiveProperty<string?> _infoBoxTitle;
 
@@ -32,9 +32,9 @@ public class InfoBoxControlsPageViewModel : ControlsGallerySubPage
     )
         : base(PageId, context)
     {
-        _severity = new ReactiveProperty<Enum>(InfoBarSeverity.Informational).DisposeItWith(
-            Disposable
-        );
+        _severity = new ReactiveProperty<InfoBarSeverity>(
+            InfoBarSeverity.Informational
+        ).DisposeItWith(Disposable);
         _infoBoxTitle = new ReactiveProperty<string?>(
             RS.InfoBoxControlsPageViewModel_Example_Title
         ).DisposeItWith(Disposable);

--- a/src/Asv.Avalonia/Core/ViewModel/Property/Historical/HistoricalEnumProperty.cs
+++ b/src/Asv.Avalonia/Core/ViewModel/Property/Historical/HistoricalEnumProperty.cs
@@ -5,14 +5,14 @@ using R3;
 namespace Asv.Avalonia;
 
 public sealed class HistoricalEnumProperty<TEnum>
-    : BindablePropertyBase<Enum, TEnum>,
-        IHistoricalProperty<Enum>
+    : BindablePropertyBase<TEnum, TEnum>,
+        IHistoricalProperty<TEnum>
     where TEnum : struct, Enum
 {
     private bool _internalChange;
-    private readonly IUndoChangeSink<ValueUndoChange<Enum>> _undoSink;
+    private readonly IUndoChangeSink<ValueUndoChange<TEnum>> _undoSink;
 
-    public HistoricalEnumProperty(string typeId, ReactiveProperty<Enum> modelValue)
+    public HistoricalEnumProperty(string typeId, ReactiveProperty<TEnum> modelValue)
         : base(typeId)
     {
         ModelValue = modelValue;
@@ -24,16 +24,16 @@ public sealed class HistoricalEnumProperty<TEnum>
         _internalChange = false;
 
         ModelValue.Subscribe(OnChangeByModel).DisposeItWith(Disposable);
-        _undoSink = Undo.RegisterValue<Enum>("default", ApplyEnumValue, ApplyEnumValue)
+        _undoSink = Undo.RegisterValue<TEnum>("default", ApplyEnumValue, ApplyEnumValue)
             .DisposeItWith(Disposable);
     }
 
-    private void ApplyEnumValue(Enum value)
+    private void ApplyEnumValue(TEnum value)
     {
         ModelValue.Value = value;
     }
 
-    public override ReactiveProperty<Enum> ModelValue { get; }
+    public override ReactiveProperty<TEnum> ModelValue { get; }
     public override BindableReactiveProperty<TEnum> ViewValue { get; }
 
     public TEnum[] EnumItems => Enum.GetValues<TEnum>();
@@ -73,27 +73,11 @@ public sealed class HistoricalEnumProperty<TEnum>
         }
     }
 
-    protected override void OnChangeByModel(Enum modelValue)
+    protected override void OnChangeByModel(TEnum modelValue)
     {
         _internalChange = true;
-        ViewValue.OnNext(GetViewValue(modelValue));
+        ViewValue.OnNext(modelValue);
         _internalChange = false;
-    }
-
-    private static TEnum GetViewValue(Enum modelValue)
-    {
-        if (modelValue is not TEnum newEnum)
-        {
-            throw new Exception($"{modelValue} is not a valid enum type for {nameof(TEnum)}");
-        }
-
-        return newEnum;
-    }
-
-    protected override ValueTask ApplyValueToModel(Enum value, CancellationToken cancel)
-    {
-        ApplyEnumValue(value);
-        return ValueTask.CompletedTask;
     }
 
     public override IEnumerable<IViewModel> GetChildren()


### PR DESCRIPTION
MessagePack cannot serialize undo values typed as System.Enum, so undo/redo breaks after any enum change. Now the property uses TEnum everywhere.